### PR TITLE
fix: rename bone claws to burning claws

### DIFF
--- a/recipes.json
+++ b/recipes.json
@@ -44060,6 +44060,6 @@
         "quantity": 1
       }
     ],
-    "name": "Making Bone claws"
+    "name": "Making Burning claws"
   }
 ]


### PR DESCRIPTION
On the 17th of July 2024 the item's name was changed.

Ref: https://oldschool.runescape.wiki/w/Burning_claws#Changes