### PR TITLE
Add toxic item dismantle

### DIFF
--- a/recipes.json
+++ b/recipes.json
@@ -27259,6 +27259,25 @@
       {
         "id": 12934,
         "quantity": 20000
+      },
+      {
+        "id": 11908,
+        "quantity": 1
+      }
+    ],
+    "inputs": [
+      {
+        "id": 12900,
+        "quantity": 1
+      }
+    ],
+    "name": "Dismantling uncharged toxic trident"
+  },
+  {
+    "outputs": [
+      {
+        "id": 12934,
+        "quantity": 20000
       }
     ],
     "inputs": [

--- a/recipes.json
+++ b/recipes.json
@@ -27274,6 +27274,25 @@
     "name": "Dismantling uncharged toxic trident"
   },
   {
+  "outputs": [
+    {
+      "id": 12934,
+      "quantity": 20000
+    },
+    {
+      "id": 11791,
+      "quantity": 1
+    }
+  ],
+  "inputs": [
+    {
+      "id": 12902,
+      "quantity": 1
+    }
+  ],
+  "name": "Dismantling Toxic staff (uncharged)"
+  },
+  {
     "outputs": [
       {
         "id": 12934,


### PR DESCRIPTION
Added dismantle recipes for:
- Toxic staff (uncharged)
- Uncharged toxic trident

I often dismantle these down to scales/leftover items and this will let me track the profit in the plugin.

